### PR TITLE
Enforce max participants limit on activity signup

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -104,6 +104,13 @@ def signup_for_activity(activity_name: str, email: str):
             status_code=400,
             detail="Student is already signed up"
         )
+    
+    # Validate max participants limit
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Activity has reached maximum capacity of {activity['max_participants']} participants"
+        )
 
     # Add student
     activity["participants"].append(email)


### PR DESCRIPTION
Cette pull request implémente une vérification de la capacité maximale des activités lors des inscriptions.

### Changements
- Ajout d'une validation avant d'ajouter un nouveau participant
- Utilisation du code d'état HTTP 409 (Conflict) quand la capacité est atteinte
- Message d'erreur clair indiquant la capacité maximale

### Tests effectués
Les scénarios suivants ont été vérifiés :
- Inscription lorsque l'activité n'est pas pleine ✅
- Tentative d'inscription lorsque la capacité maximale est atteinte ❌
- Les autres vérifications existantes continuent de fonctionner (activité inexistante, inscription en double) ✅

Fixes #13